### PR TITLE
Speed up, preserve date/time/attrs

### DIFF
--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -8,11 +8,11 @@ with conn:
 	cur = conn.cursor()    
     
     # Get files with duplicates
-	cur.execute("SELECT chksum, COUNT(*) c FROM files GROUP BY chksum HAVING c > 1;")
+	cur.execute("SELECT chksumfull, COUNT(*) c FROM files WHERE chksumfull != '' GROUP BY chksum HAVING c > 1")
 	results = cur.fetchall()
 	for result in results:
 		dupscur = conn.cursor()
-		dupscur.execute("select file from files where chksum = '"+ result[0]+"';")
+		dupscur.execute("SELECT file FROM files WHERE chksumfull = ?", (result[0],) )
 		#Get all duplicate files
 		dupesResults = dupscur.fetchall()
 		fileIndex = 0 

--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os, sqlite3, subprocess, xattr, pickle
 
+cwd = os.path.abspath(os.path.curdir)
 conn = sqlite3.connect('clonefile-index.sqlite')
 
 with conn:
@@ -25,11 +26,22 @@ with conn:
 				fname = dupesResult[0]
 				fnameNew = fname + ".cfdnew"
 				print(f"    replacing: {fname}")
-				# The -c parameter is for the `clonefile`
-				copyCommand = subprocess.run(['cp', '-cv', originalFile, fnameNew], stdout=subprocess.PIPE)
-				#print(copyCommand)
+
 				oldStat = os.stat(fname)
 				oldAttr = dict(xattr.xattr(fname))
+
+				dirName = os.path.abspath(os.path.dirname(fname))
+				oldDirStat = [ ] 
+				
+				d = dirName
+				while d != '/' and d != '' and d != cwd:
+					oldDirStat.append( (d, os.stat(d)) )
+					d = os.path.abspath(os.path.dirname(d))
+
+				# The -c parameter is for the `clonefile`
+				copyCommand = subprocess.run(['cp', '-cvp', originalFile, fnameNew], stdout=subprocess.PIPE)
+				#print(copyCommand)
+
 				newStat = os.stat(fnameNew) 
 				newAttr = dict(xattr.xattr(fnameNew))
 
@@ -52,6 +64,12 @@ with conn:
 				fnameNew = fname
 				newStat = os.stat(fnameNew) 
 				newAttr = dict(xattr.xattr(fnameNew))
+				newDirStat = []
+
+				d = dirName
+				while d != '/' and d != '' and d != cwd:
+					newDirStat.append( (d, os.stat(d)) ) 
+					d = os.path.abspath(os.path.dirname(d))
 
 				# additional fixup, just in case:
 				if newStat.st_uid != oldStat.st_uid or newStat.st_gid != oldStat.st_gid:
@@ -66,6 +84,12 @@ with conn:
 
 				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
 					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
+
+				for nd,od in zip(newDirStat, oldDirStat):
+					if nd[0] != od[0]:
+						continue
+					if nd[1].st_mtime != od[1].st_mtime or nd[1].st_atime != od[1].st_atime:
+						os.utime(od[0], (od[1].st_atime, od[1].st_mtime) )
 
 			fileIndex += 1
 

--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -31,12 +31,7 @@ with conn:
 				oldAttr = dict(xattr.xattr(fname))
 
 				dirName = os.path.abspath(os.path.dirname(fname))
-				oldDirStat = [ ] 
-				
-				d = dirName
-				while d != '/' and d != '' and d != cwd:
-					oldDirStat.append( (d, os.stat(d)) )
-					d = os.path.abspath(os.path.dirname(d))
+				oldDirStat = os.stat(dirName)
 
 				# The -c parameter is for the `clonefile`
 				copyCommand = subprocess.run(['cp', '-cvp', originalFile, fnameNew], stdout=subprocess.PIPE)
@@ -64,12 +59,7 @@ with conn:
 				fnameNew = fname
 				newStat = os.stat(fnameNew) 
 				newAttr = dict(xattr.xattr(fnameNew))
-				newDirStat = []
-
-				d = dirName
-				while d != '/' and d != '' and d != cwd:
-					newDirStat.append( (d, os.stat(d)) ) 
-					d = os.path.abspath(os.path.dirname(d))
+				newDirStat = os.stat(dirName)
 
 				# additional fixup, just in case:
 				if newStat.st_uid != oldStat.st_uid or newStat.st_gid != oldStat.st_gid:
@@ -85,11 +75,8 @@ with conn:
 				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
 					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
 
-				for nd,od in zip(newDirStat, oldDirStat):
-					if nd[0] != od[0]:
-						continue
-					if nd[1].st_mtime != od[1].st_mtime or nd[1].st_atime != od[1].st_atime:
-						os.utime(od[0], (od[1].st_atime, od[1].st_mtime) )
+				if newDirStat.st_mtime != oldDirStat.st_mtime or newDirStat.st_atime != oldDirStat.st_atime:
+					os.utime(dirName, (oldDirStat.st_atime, oldDirStat.st_mtime) )
 
 			fileIndex += 1
 

--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sqlite3, subprocess
+import os, sqlite3, subprocess, xattr, pickle
 
 conn = sqlite3.connect('clonefile-index.sqlite')
 
@@ -8,7 +8,7 @@ with conn:
 	cur = conn.cursor()    
     
     # Get files with duplicates
-	cur.execute("SELECT chksumfull, COUNT(*) c FROM files WHERE chksumfull != '' GROUP BY chksum HAVING c > 1")
+	cur.execute("SELECT chksumfull, COUNT(*) c FROM files WHERE chksumfull != '' GROUP BY chksumfull HAVING c > 1 ORDER BY size DESC")
 	results = cur.fetchall()
 	for result in results:
 		dupscur = conn.cursor()
@@ -19,13 +19,54 @@ with conn:
 		#For the first one, treat this as the original even though it doesn't matter which one you use. 
 		for dupesResult in dupesResults:
 			if fileIndex == 0: 
-				print("Original file: " + dupesResult[0])
+				print(f"Original file: {dupesResult[0]}    size {os.path.getsize(dupesResult[0])}")
 				originalFile = dupesResult[0]
-			else: 
-				print("Copy: " + dupesResult[0])
+			else:
+				fname = dupesResult[0]
+				fnameNew = fname + ".cfdnew"
+				print(f"    replacing: {fname}")
 				# The -c parameter is for the `clonefile`
-				copyCommand = subprocess.run(['cp', '-cv', originalFile, dupesResult[0]], stdout=subprocess.PIPE)
-				print(copyCommand)
+				copyCommand = subprocess.run(['cp', '-cv', originalFile, fnameNew], stdout=subprocess.PIPE)
+				#print(copyCommand)
+				oldStat = os.stat(fname)
+				oldAttr = dict(xattr.xattr(fname))
+				newStat = os.stat(fnameNew) 
+				newAttr = dict(xattr.xattr(fnameNew))
+
+				if newStat.st_uid != oldStat.st_uid or newStat.st_gid != oldStat.st_gid:
+					os.chown(fnameNew, oldStat.st_uid, oldStat.st_gid)
+
+				if newStat.st_mode != oldStat.st_mode:
+					os.chmod(fnameNew, oldStat.st_mode)
+
+				if pickle.dumps(oldAttr)!=pickle.dumps(newAttr):
+					for k,v in oldAttr.items():
+						xattr.setxattr(fnameNew, k, v)
+
+				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
+					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
+
+				moveCommand = subprocess.run(['mv', '-f', fnameNew, fname], stdout=subprocess.PIPE)
+				#print(moveCommand)
+
+				fnameNew = fname
+				newStat = os.stat(fnameNew) 
+				newAttr = dict(xattr.xattr(fnameNew))
+
+				# additional fixup, just in case:
+				if newStat.st_uid != oldStat.st_uid or newStat.st_gid != oldStat.st_gid:
+					os.chown(fnameNew, oldStat.st_uid, oldStat.st_gid)
+
+				if newStat.st_mode != oldStat.st_mode:
+					os.chmod(fnameNew, oldStat.st_mode)
+
+				if pickle.dumps(oldAttr)!=pickle.dumps(newAttr):
+					for k,v in oldAttr.items():
+						xattr.setxattr(fnameNew, k, v)
+
+				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
+					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
+
 			fileIndex += 1
 
 conn.close()

--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -19,7 +19,11 @@ with conn:
 		fileIndex = 0 
 		#For the first one, treat this as the original even though it doesn't matter which one you use. 
 		for dupesResult in dupesResults:
-			if fileIndex == 0: 
+			if not os.path.isfile(dupesResult[0]):
+				continue
+			if os.path.islink(dupesResult[0]):
+				continue
+			if fileIndex == 0:
 				print(f"Original file: {dupesResult[0]}    size {os.path.getsize(dupesResult[0])}")
 				originalFile = dupesResult[0]
 			else:

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
 	allfiles = []
 	sqlite_data = []
 
-	print(f'Found {len(results)} candidates, fetching files')
+	print(f'Found {len(results)} non-unique checksums, fetching files')
 	for result in tqdm(results):
 		c.execute("SELECT file FROM files WHERE chksum64k = ?", (result[0],))
 		for f in c.fetchall():

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -2,7 +2,7 @@
 import os, sqlite3, hashlib, json
 from tqdm import tqdm
 from os import listdir
-from os.path import isfile, join
+from os.path import isfile, islink, join
 from multiprocessing import Pool
 from pathlib import Path
 
@@ -75,8 +75,8 @@ if __name__ == '__main__':
 	print(f"Reading file list")
 	for dirpath, dirnames, filenames in os.walk("."):
 		for filename in [f for f in filenames]:
-			filelink =  os.path.join(dirpath, filename)
-			if (isfile(filelink)):
+			filelink = os.path.abspath(os.path.join(dirpath, filename))
+			if isfile(filelink) and not islink(filelink):
 				allfiles.append(filelink)
 	num_of_files = len(allfiles)
 	# "threads" at a time, multiprocess delegation

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sqlite3, hashlib, json, xattr
+import os, sqlite3, hashlib, json
 from tqdm import tqdm
 from os import listdir
 from os.path import isfile, join
@@ -16,7 +16,7 @@ threads = input("Number of Threads to use: ")
 
 conn = sqlite3.connect('clonefile-index.sqlite')
 c = conn.cursor()
-c.execute('''CREATE TABLE files (file, chksum64k, chksumfull, size, stat, xattr)''')
+c.execute('''CREATE TABLE files (file, chksum64k, chksumfull, size, stat)''')
 
 def processFile(filelink):
 	try: 
@@ -31,7 +31,6 @@ def processFile(filelink):
 				file_info = (
 					filelink, shahash, os.path.getsize(filelink),
 					json.dumps(os.stat(filelink)),
-					json.dumps(dict(xattr.xattr(filelink))),
 				)
 				return file_info
 			except Exception as e: 
@@ -60,12 +59,12 @@ def add2sqlite(fileinfo):
 		if (f != None):
 			if f[2]>BLOCKSIZE:
 				c.execute(
-					"INSERT INTO files (file, chksum64k, chksumfull, size, stat, xattr) VALUES (?,?,?,?,?,?)",
-					(f[0], f[1], '',   f[2], f[3], f[4]))
+					"INSERT INTO files (file, chksum64k, chksumfull, size, stat) VALUES (?,?,?,?,?)",
+					(f[0], f[1], '',   f[2], f[3]) )
 			else:
 				c.execute(
-					"INSERT INTO files (file, chksum64k, chksumfull, size, stat, xattr) VALUES (?,?,?,?,?,?)",
-					(f[0], f[1], f[1], f[2], f[3], f[4]))
+					"INSERT INTO files (file, chksum64k, chksumfull, size, stat) VALUES (?,?,?,?,?)",
+					(f[0], f[1], f[1], f[2], f[3]) )
 
 # Index all files from within the root
 #start script

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
 			allfiles.append(f[0])
 
 	num_of_files = len(allfiles)
-	print("Processing {num_of_files} files")
+	print(f"Calculating full checksum for {num_of_files} files")
 	with Pool(int(threads)) as pool:
 		r = list(tqdm(pool.imap_unordered(processFileFull, allfiles), total = num_of_files))
 

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
 
 	conn.commit()
 	print('Indexing database')
-	c.execute('''CREATE INDEX indexfull ON files(chksum64k ASC, chksumfull ASC)''')
+	c.execute('''CREATE INDEX indexfull ON files(chksumfull ASC)''')
 
 conn.commit()
 conn.close()

--- a/clonefile-index.py
+++ b/clonefile-index.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
 
 	print(f'Found {len(results)} non-unique checksums, fetching files')
 	for result in tqdm(results):
-		c.execute("SELECT file FROM files WHERE chksum64k = ? AND chksumfull != ''", (result[0],))
+		c.execute("SELECT file FROM files WHERE chksum64k = ? AND chksumfull == ''", (result[0],))
 		for f in c.fetchall():
 			allfiles.append(f[0])
 

--- a/clonefile-verify.py
+++ b/clonefile-verify.py
@@ -4,23 +4,23 @@ import sqlite3, subprocess
 conn = sqlite3.connect('clonefile-index.sqlite')
 
 with conn:
-    
-	cur = conn.cursor()    
-    
-	cur.execute("SELECT chksum, COUNT(*) c FROM files GROUP BY chksum HAVING c > 1;")
+
+	cur = conn.cursor()
+
+	cur.execute("SELECT chksumfull, COUNT(*) c FROM files WHERE chksumfull != '' GROUP BY chksumfull HAVING c > 1")
 	results = cur.fetchall()
 	for result in results:
 		dupscur = conn.cursor()
-		dupscur.execute("select file from files where chksum = '"+ result[0]+"';")
-		# print(result)		
+		dupscur.execute("SELECT file FROM files WHERE chksumfull = ?", (result[0],) )
+		# print(result)
 		dupesResults = dupscur.fetchall()
-		fileIndex = 0 
+		fileIndex = 0
 		for dupesResult in dupesResults:
 			print("Verifying file: " + dupesResult[0])
 			chksumRaw = subprocess.run(['shasum', '-a', '256', dupesResult[0]], stdout=subprocess.PIPE)
 			chksum = chksumRaw.stdout.split()[0].decode("utf-8")
 			print("Original checksum: \t \t "+ result[0])
-			print("New file: \t \t \t "+ chksum)			
+			print("New file: \t \t \t "+ chksum)
 			# I should probably add some logic here to ignore Spotlight search files. 
 			if chksum == result[0]:
 				print("\033[1;32mVerified!!\033[1;m")

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Instructions:
 
 1. Run `clonefile-index.py` which will create an `index.sqlite` database with all of the files and chksums at the scriptroot. 
 2. Run `clonefile-dedup.py` which will copy the first instance of a file to all of the other instances using the 'clonefile' syscall. This isn't a link but an APFS reference to the same data on the drive that is used by a file with that chksum. 
-3. (optional) Run `clonefile-verify.py` to verify that the files bear the same chksum after as they did before the process. If you use Spotlight on this drive, it will definitely display an error on these files. 
+3. (optional) Run `clonefile-verify.py` to verify that the files bear the same chksum after as they did before the process. If you use Spotlight on this drive, it will definitely display an error on the Spotlight metadata files. 
 
 Let me know how it works out for you! 
 Twitter: @ranvel

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Normal deduplication is done at the block level and requires a special filesyste
 
 You'll need:
  - python 3.6
- - python sqlite3 & tqdm module
+ - python sqlite3, tqdm and xattr modules
  - a Mac with APFS (to utilize the clonefile syscall)
 
 This program could easily be combined into one program, but it's not a lot of work to run this as separate scripts, so I will leave it as is. 


### PR DESCRIPTION
- Normally only calculates the checksum for the first 64k, if matches: then calculates a full checksum.
- Added SQLite indices to speed up processing
- Preserve chmod/chown/time/xattr of the original file
- use a two stage cp, mv procedure, so that even if stopped midway things don't get corrupted

I haven't tested it extensively, but it seemed to work for me just fine to dedupe my source code directory