### PR TITLE
Add argparse and handle xattr set exceptions

### DIFF
--- a/clonefile-dedup.py
+++ b/clonefile-dedup.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
-import os, sqlite3, subprocess, xattr, pickle
+import os, sqlite3, subprocess, xattr, pickle, argparse
 
-cwd = os.path.abspath(os.path.curdir)
-conn = sqlite3.connect('clonefile-index.sqlite')
+parser = argparse.ArgumentParser()
+parser.add_argument("dirpath", type=str, nargs='?', default=os.path.curdir,
+		help="directory under which the dedup runs recursively")
+parser.add_argument("--cp-path", type=str, default='cp',
+		help="path to Mac's built-in (BSD) cp binaries (/bin/cp ?)")
+parser.add_argument("--mv-path", type=str, default='mv',
+		help="path to Mac's built-in (BSD) mv binaries (/bin/mv ?)")
+args = parser.parse_args()
+
+assert os.path.isdir(args.dirpath), "directory path invalid: %s" % args.dirpath
+cwd = os.path.abspath(args.dirpath)
+DB_PATH = os.path.abspath(os.path.join(cwd, 'clonefile-index.sqlite')) 
+assert os.path.isfile(DB_PATH), 'no db found under "%s";\ndid you run clonefile-index.py first?' % DB_PATH
+
+conn = sqlite3.connect(DB_PATH)
 
 with conn:
-    
-	cur = conn.cursor()    
-    
-    # Get files with duplicates
+	cur = conn.cursor()
+
+	# Get files with duplicates
 	cur.execute("SELECT chksumfull, COUNT(*) c FROM files WHERE chksumfull != '' GROUP BY chksumfull HAVING c > 1 ORDER BY size DESC")
 	results = cur.fetchall()
 	for result in results:
@@ -38,7 +50,7 @@ with conn:
 				oldDirStat = os.stat(dirName)
 
 				# The -c parameter is for the `clonefile`
-				copyCommand = subprocess.run(['cp', '-cvp', originalFile, fnameNew], stdout=subprocess.PIPE)
+				copyCommand = subprocess.run([args.cp_path, '-cvp', originalFile, fnameNew], stdout=subprocess.PIPE)
 				#print(copyCommand)
 
 				newStat = os.stat(fnameNew) 
@@ -52,12 +64,17 @@ with conn:
 
 				if pickle.dumps(oldAttr)!=pickle.dumps(newAttr):
 					for k,v in oldAttr.items():
-						xattr.setxattr(fnameNew, k, v)
+						try:
+							xattr.setxattr(fnameNew, k, v)
+						except:
+							prompt_text = 'failed to modify attribute "%s" for "%s"\n' % (k, fnameNew)
+							prompt_text += 'press return to ignore; ctrl+C to abort '
+							input(prompt_text)
 
 				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
 					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
 
-				moveCommand = subprocess.run(['mv', '-f', fnameNew, fname], stdout=subprocess.PIPE)
+				moveCommand = subprocess.run([args.mv_path, '-f', fnameNew, fname], stdout=subprocess.PIPE)
 				#print(moveCommand)
 
 				fnameNew = fname
@@ -74,14 +91,28 @@ with conn:
 
 				if pickle.dumps(oldAttr)!=pickle.dumps(newAttr):
 					for k,v in oldAttr.items():
-						xattr.setxattr(fnameNew, k, v)
+						try:
+							xattr.setxattr(fnameNew, k, v)
+						except:
+							prompt_text = 'failed to modify attribute "%s" for "%s"\n' % (k, fnameNew)
+							prompt_text += 'press return to ignore; ctrl+C to abort '
+							input(prompt_text)
 
 				if newStat.st_mtime != oldStat.st_mtime or newStat.st_atime != oldStat.st_atime:
-					os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
+					try:
+						os.utime(fnameNew, (oldStat.st_atime, oldStat.st_mtime) )
+					except PermissionError:
+						prompt_text = 'permission error while setting file %s\n' % fnameNew
+						prompt_text += 'press return to ignore; ctrl+C to abort '
+						input(prompt_text)
 
 				if newDirStat.st_mtime != oldDirStat.st_mtime or newDirStat.st_atime != oldDirStat.st_atime:
-					os.utime(dirName, (oldDirStat.st_atime, oldDirStat.st_mtime) )
+					try:
+						os.utime(dirName, (oldDirStat.st_atime, oldDirStat.st_mtime))
+					except PermissionError:
+						prompt_text = 'permission error while setting dir %s\n' % dirName
+						prompt_text += 'press return to ignore; ctrl+C to abort '
+						input(prompt_text)
 
 			fileIndex += 1
-
 conn.close()


### PR DESCRIPTION
* allow overriding the path for the dedup to run
* allow overriding the path to cp (in case of GNU cp take priority in $PATH)
* allow overriding the path to mv
* catch exception when seeing error for setting attribute to either file or directory; prompt user for either continue or abort

When i used it with a Mac (running the lates 10.15.4), i experienced few issues. Made those changes for it to go through
1. i have gnu core utils installed, so they take place for `mv` and `cp` when calling from shell, but GNU cp doesn't have the clone feature. Added argparse to allow user override to the built-in BSD ones
2. I experience an issue such that some copies of my file will get marked `com.apple.quarantine`, which the xattr setter cannot change without root permission. instead of exiting with error, i have it to prompt user for either continue or abort.
3. I also experienced issue with setting directory permission, in particular the permission exception i got came out of `/Volume/my-volume-name`. Made similar handling as above. 